### PR TITLE
Fixed broken link to bna PDF

### DIFF
--- a/prereqs/ComputationalNeuroscience.md
+++ b/prereqs/ComputationalNeuroscience.md
@@ -30,7 +30,7 @@ We highly recommend going through our refreshers on linear algebra, calculus, an
 
 ### Neuroscience
 
-If you're coming from outside neuroscience, it'll be great to familiarize yourself with fundamental concepts. We highly recommend watching our NMA neuro video series before the course (W0D0 [here](https://compneuro.neuromatch.io/)). Here is a [short read on the subject](https://brain.mcmaster.ca/BrainBee/Neuroscience.Science.of.the.Brain.pdf). Here is another resource from [the Brain Facts book by Society For Neuroscience](https://www.brainfacts.org/the-brain-facts-book).
+If you're coming from outside neuroscience, it'll be great to familiarize yourself with fundamental concepts. We highly recommend watching our NMA neuro video series before the course (W0D0 [here](https://compneuro.neuromatch.io/)). Here is a [short read on the subject]([https://brain.mcmaster.ca/BrainBee/Neuroscience.Science.of.the.Brain.pdf](https://www.uni-heidelberg.de/md/izn/teaching/neuroscience/img/neuroscience-of-the-brain-english.pdf)). Here is another resource from [the Brain Facts book by Society For Neuroscience](https://www.brainfacts.org/the-brain-facts-book).
 
 We're so excited to have you here! Looking forward to meeting you soon,
 

--- a/prereqs/ComputationalNeuroscience.md
+++ b/prereqs/ComputationalNeuroscience.md
@@ -30,7 +30,7 @@ We highly recommend going through our refreshers on linear algebra, calculus, an
 
 ### Neuroscience
 
-If you're coming from outside neuroscience, it'll be great to familiarize yourself with fundamental concepts. We highly recommend watching our NMA neuro video series before the course (W0D0 [here](https://compneuro.neuromatch.io/)). Here is a [short read on the subject]([https://brain.mcmaster.ca/BrainBee/Neuroscience.Science.of.the.Brain.pdf](https://www.uni-heidelberg.de/md/izn/teaching/neuroscience/img/neuroscience-of-the-brain-english.pdf)). Here is another resource from [the Brain Facts book by Society For Neuroscience](https://www.brainfacts.org/the-brain-facts-book).
+If you're coming from outside neuroscience, it'll be great to familiarize yourself with fundamental concepts. We highly recommend watching our NMA neuro video series before the course (W0D0 [here](https://compneuro.neuromatch.io/)). Here is a [short read on the subject](https://www.uni-heidelberg.de/md/izn/teaching/neuroscience/img/neuroscience-of-the-brain-english.pdf). Here is another resource from [the Brain Facts book by Society For Neuroscience](https://www.brainfacts.org/the-brain-facts-book).
 
 We're so excited to have you here! Looking forward to meeting you soon,
 

--- a/prereqs/ComputationalNeuroscience.md
+++ b/prereqs/ComputationalNeuroscience.md
@@ -30,7 +30,7 @@ We highly recommend going through our refreshers on linear algebra, calculus, an
 
 ### Neuroscience
 
-If you're coming from outside neuroscience, it'll be great to familiarize yourself with fundamental concepts. We highly recommend watching our NMA neuro video series before the course (W0D0 [here](https://compneuro.neuromatch.io/)). Here is a [short read on the subject](https://www.bna.org.uk/static/uploads/resources/BNA_English.pdf). Here is another resource from [the Brain Facts book by Society For Neuroscience](https://www.brainfacts.org/the-brain-facts-book).
+If you're coming from outside neuroscience, it'll be great to familiarize yourself with fundamental concepts. We highly recommend watching our NMA neuro video series before the course (W0D0 [here](https://compneuro.neuromatch.io/)). Here is a [short read on the subject](https://brain.mcmaster.ca/BrainBee/Neuroscience.Science.of.the.Brain.pdf). Here is another resource from [the Brain Facts book by Society For Neuroscience](https://www.brainfacts.org/the-brain-facts-book).
 
 We're so excited to have you here! Looking forward to meeting you soon,
 


### PR DESCRIPTION
## This PR solves #129 

There is a broken link to the document titled: **NEUROSCIENCE- SCIENCE OF THE BRAIN: AN INTRODUCTION FOR YOUNG STUDENTS from British Neuroscience Association European Data Alliance for the Brain**.

This had this link previously: https://www.bna.org.uk/static/uploads/resources/BNA_English.pdf. But this returns **Access Denied**.

<summary>Full JSON response below.</summary>

<details>

```
<Error>
<Code>AccessDenied</Code>
<Message>Access Denied</Message>
<RequestId>[REDACTED BY RITOG]</RequestId>
<HostId>
[REDACTED BY RITOG]
</HostId>
</Error>
```
</details>

This document can be found in the server of another institute, and I have added that link: https://brain.mcmaster.ca/BrainBee/Neuroscience.Science.of.the.Brain.pdf

<img width="1565" height="990" alt="image" src="https://github.com/user-attachments/assets/15176360-b0a7-4d27-a4bc-36374fcba1ce" />

It is from MacMaster University, and I think this link will be stable. At least for a while.

### How do I know it is the same file?

I searched the URL in Google. Click [link](https://www.google.com/search?q=https%3A%2F%2Fwww.bna.org.uk%2Fstatic%2Fuploads%2Fresources%2FBNA_English.pdf) for performing the same search.

And, in that search, [this link of a reading list](https://leicester.rl.talis.com/lists/F685AA76-7E66-216D-C3B1-0144BED21290/bibliography.pdf?style=bibtex) came up, where the URL matches with the missing file URL.

<img width="759" height="125" alt="image" src="https://github.com/user-attachments/assets/92a37bd6-385b-42c8-a29e-00593b768799" />

So, I searched using the title, and the link that I have inserted, came up. [Search link](https://www.google.com/search?q=Neuroscience+-+Science+of+the+Brain)